### PR TITLE
GetMapping 오류

### DIFF
--- a/src/main/java/com/example/jscodestudy/controller/BoardController.java
+++ b/src/main/java/com/example/jscodestudy/controller/BoardController.java
@@ -35,7 +35,7 @@ public class BoardController {
         return "redirect:/";
     }
 
-    @RequestMapping(value = "/post/{no}", method={RequestMethod.GET})
+    @RequestMapping(value = "/post/{no}", method={RequestMethod.GET}) //@GetMapping 오류
     public String detail(@PathVariable("no") Long id, Model model) {
         BoardDto boardDto = boardService.getPost(id);
 


### PR DESCRIPTION
제가 이번 주는 따로 develope을 못해서 오류를 해결했지만 이해하지 못한 부분에서 질문드립니다!

controller에 @RequestMapping 부분에서 

```java
@RequestMapping
(value = "/post/{no}", method={RequestMethod.GET})부분을

@GetMapping
("/post/{no}")로만 받았었는데
```

이렇게 작성하니 특정 게시글로의 접근이 되지 않았었는데 GET방식으로의 요청을 하는 메소드 코드를 넣으니 정상작동하였습니다. method 부분을 작성하지 않으면 기본적으로 post방식으로의 요청이 되는건지 post방식 메서드를 따로 작성해주어야 하는지 궁금합니다